### PR TITLE
Get fields from Datasilo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
   },
   "dependencies": {
     "autoprefixer": "^6.3.3",
+    "aws-v4-sign-small": "^1.1.1",
     "baobab": "^2.3.3",
     "bluebird": "^3.4.0",
+    "bn.js": "^4.11.6",
     "cerebral": "^0.35.7",
     "cerebral-addons": "^0.6.1",
     "cerebral-baobab": "^0.4.5",
@@ -67,7 +69,8 @@
     "superagent-promise": "^1.1.0",
     "togeojson": "^0.14.2",
     "url-loader": "^0.5.7",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "wellknown": "^0.5.0"
   },
   "devDependencies": {
     "babel-core": "^6.14.0",
@@ -81,6 +84,7 @@
     "cross-env": "^1.0.7",
     "css-loader": "^0.23.1",
     "postcss-loader": "^0.8.1",
-    "style-loader": "^0.13.0"
+    "style-loader": "^0.13.0",
+    "webpack": "^1.14.0"
   }
 }

--- a/src/modules/app/utils/datasilo.js
+++ b/src/modules/app/utils/datasilo.js
@@ -1,0 +1,55 @@
+import {sign as awsSign} from 'aws-v4-sign-small';
+import request from 'superagent';
+var agent = require('superagent-promise')(require('superagent'), Promise);
+
+// Config of datasilo -- much is fixed / or should be protected
+let conf = {
+  secretKeyId: 'AKIAIUWOPGZ6F4A6A3MQ',
+  secretKey: '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',
+  host: 'api.winfielddatasilo.com',
+  region: 'us-east-1',
+  service: 'execute-api',
+  environment: 'qa',
+  apiKey: 'pZauSIzZng2hT3bCqivi5aDsUlyTwLbL6s3HjPi1'
+};
+
+// Public API
+
+function getGrower() {
+  return get('grower', 'application/vnd.datasilo.v1.json', {
+    expand: 'farm,field,season'
+  });
+}
+
+export {getGrower};
+
+//// Helper functions
+function get(path, accept, query) {
+	var opts = {
+		host: conf.host,
+		region: conf.region,
+		service: conf.service,
+		method: 'get',
+    path: `/${conf.environment}/${path}`,
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+			'Accept': accept,
+			'x-api-key': conf.apiKey,
+		},
+		query
+	};
+
+
+  var req = awsSign(opts, {
+		accessKeyId: conf.secretKeyId,
+		secretAccessKey: conf.secretKey
+	});
+
+  // Not safe to change the host header
+  req.headers.host = undefined;
+
+  return agent('GET', `https://${conf.host}${opts.path}`)
+		.set(req.headers)
+		.end()
+    .then(response => response.body);
+}


### PR DESCRIPTION
Adds fetching fields from Datasilo

Notes:

1. I tried to convert the datasilo format to the oada format. I don't really understand `context` so I am not sure if I got that right. I added the season to the field name to avoid possible duplicates over seasons. Will trialstracker (and the oada field format) support seasons at some point?

2. You can switch `getFieldsFromDatasilo` back to `getFields` in the `drawFirstGeohashes` chain to go back to oada fields.

3. We might want to get fields from both sources?

4. `datasilo.js` can become its own library as we create more datasilo integration